### PR TITLE
Fix iregex case insensetive not working with cyrillic characters

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -226,7 +226,7 @@ public class ConditionNBT extends CITCondition {
 
         public static class IRegexMatcher extends RegexMatcher {
             public IRegexMatcher(String pattern) {
-                super(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE));
+                super(Pattern.compile(pattern, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
             }
         }
 


### PR DESCRIPTION
Example item: https://paste.gg/p/anonymous/9e52eddb3fb947258bf6ae36d8a2932d
Without fix: https://imgur.com/a/Bcv9p5x
With fix: https://imgur.com/a/t0UskG9