### PR TITLE
Add null checks to enchantment type

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/types/TypeEnchantment.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/types/TypeEnchantment.java
@@ -209,16 +209,16 @@ public class TypeEnchantment extends CITType {
                 for (WeakReference<CIT<TypeEnchantment>> citRef : cits)
                     if (citRef != null) {
                         CIT<TypeEnchantment> cit = citRef.get();
-                        if (cit != null) {
+                        if (appliedContext != null && cit != null) {
                             appliedContext.add(cit);
                             if (cit.type.useGlint)
                                 defaultGlint = true;
                         }
                     }
-
-            if (appliedContext.isEmpty())
+            
+            if (appliedContext != null && appliedContext.isEmpty())
                 appliedContext = null;
-            else
+            else if(appliedContext != null) 
                 globalMergeMethod.applyMethod(appliedContext, context);
 
             return this;


### PR DESCRIPTION
fixes crashes with custom enchants. ( #253 )  this doesn't fix the issue of appliedContext being null when it shouldn't be, but it prevents the game from crashing.