### PR TITLE
Add new condition 'numberOfEnchantments' in 'defaults'

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,1 +1,1 @@
- - Updated to 1.20
+- Added the option to specify the mumber of enchantments an item has via `numberOfEnchantments` or `enchantmentCount`

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNumberOfEnchantments.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNumberOfEnchantments.java
@@ -1,0 +1,21 @@
+package shcm.shsupercm.fabric.citresewn.defaults.cit.conditions;
+
+import io.shcm.shsupercm.fabric.fletchingtable.api.Entrypoint;
+import shcm.shsupercm.fabric.citresewn.api.CITConditionContainer;
+import shcm.shsupercm.fabric.citresewn.cit.CITContext;
+import shcm.shsupercm.fabric.citresewn.cit.builtin.conditions.IntegerCondition;
+
+public class ConditionNumberOfEnchantments extends IntegerCondition {
+    @Entrypoint(CITConditionContainer.ENTRYPOINT)
+    public static final CITConditionContainer<ConditionNumberOfEnchantments> CONTAINER = new CITConditionContainer<>(ConditionNumberOfEnchantments.class, ConditionNumberOfEnchantments::new,
+            "numberOfEnchantments", "enchantmentCount");
+
+    public ConditionNumberOfEnchantments() {
+        super(true, false, false);
+    }
+
+    @Override
+    protected int getValue(CITContext context) {
+        return context.enchantments().size();
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.workers.max=1
 
 # CIT Resewn
-mod.version=1.1.3
+mod.version=1.1.4
 mod.jarname=citresewn
 mod.target-mc=[VERSIONED]
 publish.target-mc=[VERSIONED]


### PR DESCRIPTION
CITs can now use the condition 'numberOfEnchantments' or 'enchantmentCount' to filter for items by their number of enchantments. Just as e.g. stackSize, it takes exact values or ranges.

Is this the right place to add this feature?

Should I update the docs as well?

edit: of course I tested the feature and it works as intended