### PR TITLE
Improve performance of NBT String parsing

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -22,6 +22,8 @@ public class ConditionNBT extends CITCondition {
     protected String[] path;
 
     protected StringMatcher matchString = null;
+    protected NbtString previousNbtString = null;
+    protected boolean previousMatch = false;
     protected NbtInt matchInteger = null;
     protected NbtByte matchByte = null;
     protected NbtFloat matchFloat = null;
@@ -123,9 +125,12 @@ public class ConditionNBT extends CITCondition {
 
     private boolean testValue(NbtElement element) {
         try {
-            if (element instanceof NbtString nbtString) //noinspection ConstantConditions
-                return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromJson(nbtString.asString()).getString());
-            else if (element instanceof NbtInt nbtInt && matchInteger != null)
+            if (element instanceof NbtString nbtString) { //noinspection ConstantConditions
+                if (nbtString.equals(previousNbtString)) return previousMatch;
+                previousNbtString = nbtString.copy();
+                previousMatch = matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromJson(nbtString.asString()).getString());
+                return previousMatch;
+            } else if (element instanceof NbtInt nbtInt && matchInteger != null)
                 return nbtInt.equals(matchInteger);
             else if (element instanceof NbtByte nbtByte && matchByte != null)
                 return nbtByte.equals(matchByte);


### PR DESCRIPTION
Currently, performance with many string-dependent CIT items being rendered is pretty much unplayable on any system.

I have a Ryzen 7 3700x and an RTX 3060ti, and this is my performance in the Hypixel Skyblock lobby with a CIT-dependent resource pack. The cache invalidation time is at the default 50ms.
![2023-08-29_18 40 35](https://github.com/SHsuperCM/CITResewn/assets/59855656/979f7112-e68e-4866-9378-58ff714a0a51)

With these changes:
![2023-08-29_18 49 38](https://github.com/SHsuperCM/CITResewn/assets/59855656/3fef2daa-1812-43b3-a7ef-3230f4d122cc)

The performance could be improved more by implementing a less naïve cache system, but this fixes a few fatal performance flaws.