### PR TITLE
Add check for a JSON element before attempting to match a string

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -19,6 +19,8 @@ public class ConditionNBT extends CITCondition {
     public static final CITConditionContainer<ConditionNBT> CONTAINER = new CITConditionContainer<>(ConditionNBT.class, ConditionNBT::new,
             "nbt");
 
+    private static final Pattern jsonBeginPattern = Pattern.compile("^[ \t\n]*\\{");
+
     protected String[] path;
 
     protected StringMatcher matchString = null;
@@ -123,9 +125,12 @@ public class ConditionNBT extends CITCondition {
 
     private boolean testValue(NbtElement element) {
         try {
-            if (element instanceof NbtString nbtString) //noinspection ConstantConditions
-                return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromJson(nbtString.asString()).getString());
-            else if (element instanceof NbtInt nbtInt && matchInteger != null)
+            if (element instanceof NbtString nbtString) { //noinspection ConstantConditions
+                var asString = nbtString.asString();
+                return matchString.matches(asString) ||
+                        (jsonBeginPattern.matcher(asString).matches()
+                                && matchString.matches(Text.Serializer.fromJson(asString).getString()));
+            } else if (element instanceof NbtInt nbtInt && matchInteger != null)
                 return nbtInt.equals(matchInteger);
             else if (element instanceof NbtByte nbtByte && matchByte != null)
                 return nbtByte.equals(matchByte);


### PR DESCRIPTION
This has previously caused massive performance issues, especially in packs that frequently match non text elements. (see https://spark.lucko.me/R6fJJ3zXOJ and the massive amounts of the trace that is taken up by JsonSyntaxExceptions and MalformedJsonExceptions that trace back to this line)

This patch first does a sanity check on the text element to see if it ever could be a JSON element.