### PR TITLE
Improve performance of NBT String parsing

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -122,27 +122,25 @@ public class ConditionNBT extends CITCondition {
     }
 
     private boolean testValue(NbtElement element) {
-        try {
-            if (element instanceof NbtString nbtString) //noinspection ConstantConditions
-                return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromLenientJson(nbtString.asString()).getString());
-            else if (element instanceof NbtInt nbtInt && matchInteger != null)
-                return nbtInt.equals(matchInteger);
-            else if (element instanceof NbtByte nbtByte && matchByte != null)
-                return nbtByte.equals(matchByte);
-            else if (element instanceof NbtFloat nbtFloat && matchFloat != null)
-                return nbtFloat.equals(matchFloat);
-            else if (element instanceof NbtDouble nbtDouble && matchDouble != null)
-                return nbtDouble.equals(matchDouble);
-            else if (element instanceof NbtLong nbtLong && matchLong != null)
-                return nbtLong.equals(matchLong);
-            else if (element instanceof NbtShort nbtShort && matchShort != null)
-                return nbtShort.equals(matchShort);
-            else if (element instanceof NbtCompound nbtCompound && matchCompound != null)
-                return NbtHelper.matches(matchCompound, nbtCompound, true);
+        if (element instanceof NbtString nbtString) //noinspection ConstantConditions
+            return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromLenientJson(nbtString.asString()).getString());
+        else if (element instanceof NbtInt nbtInt && matchInteger != null)
+            return nbtInt.equals(matchInteger);
+        else if (element instanceof NbtByte nbtByte && matchByte != null)
+            return nbtByte.equals(matchByte);
+        else if (element instanceof NbtFloat nbtFloat && matchFloat != null)
+            return nbtFloat.equals(matchFloat);
+        else if (element instanceof NbtDouble nbtDouble && matchDouble != null)
+            return nbtDouble.equals(matchDouble);
+        else if (element instanceof NbtLong nbtLong && matchLong != null)
+            return nbtLong.equals(matchLong);
+        else if (element instanceof NbtShort nbtShort && matchShort != null)
+            return nbtShort.equals(matchShort);
+        else if (element instanceof NbtCompound nbtCompound && matchCompound != null)
+            return NbtHelper.matches(matchCompound, nbtCompound, true);
 
-            if (element instanceof AbstractNbtNumber nbtNumber && !(matchString instanceof StringMatcher.DirectMatcher))
-                return matchString.matches(String.valueOf(nbtNumber.numberValue()));
-        } catch (Exception ignored) { }
+        if (element instanceof AbstractNbtNumber nbtNumber && !(matchString instanceof StringMatcher.DirectMatcher))
+            return matchString.matches(String.valueOf(nbtNumber.numberValue()));
         return false;
     }
 

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -124,7 +124,7 @@ public class ConditionNBT extends CITCondition {
     private boolean testValue(NbtElement element) {
         try {
             if (element instanceof NbtString nbtString) //noinspection ConstantConditions
-                return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromJson(nbtString.asString()).getString());
+                return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromLenientJson(nbtString.asString()).getString());
             else if (element instanceof NbtInt nbtInt && matchInteger != null)
                 return nbtInt.equals(matchInteger);
             else if (element instanceof NbtByte nbtByte && matchByte != null)


### PR DESCRIPTION
As [my last PR](https://github.com/SHsuperCM/CITResewn/pull/311) was closed after a review instead of giving me time to implement the requested changes, I'm opening another one. This still gives roughly the same performance boost as #311; see that for screenshots.

This PR implements a much less intrusive optimization, adding only 7 characters to 1 line of code. It should not change the behavior of CITResewn in any way, shape, or form.

The second commit might be slightly more "controversial" since I didn't do extensive testing to see if it would/could throw any other exception. The owner may choose not to include this commit.