### PR TITLE
avoid parsing nbt strings if they do not smell like JSON

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -19,6 +19,8 @@ public class ConditionNBT extends CITCondition {
     public static final CITConditionContainer<ConditionNBT> CONTAINER = new CITConditionContainer<>(ConditionNBT.class, ConditionNBT::new,
             "nbt");
 
+    private static final Pattern jsonBeginPattern = Pattern.compile("^\s*[\\{\\[].*");
+
     protected String[] path;
 
     protected StringMatcher matchString = null;
@@ -123,8 +125,12 @@ public class ConditionNBT extends CITCondition {
 
     private boolean testValue(NbtElement element) {
         try {
-            if (element instanceof NbtString nbtString) //noinspection ConstantConditions
-                return matchString.matches(nbtString.asString()) || matchString.matches(Text.Serializer.fromJson(nbtString.asString()).getString());
+            if (element instanceof NbtString nbtString) { // noinspection ConstantConditions
+                String str = nbtString.asString();
+                return matchString.matches(str) || (
+                    jsonBeginPattern.matcher(str).matches() && matchString.matches(Text.Serializer.fromJson(str).getString())
+                );
+            }
             else if (element instanceof NbtInt nbtInt && matchInteger != null)
                 return nbtInt.equals(matchInteger);
             else if (element instanceof NbtByte nbtByte && matchByte != null)


### PR DESCRIPTION
repro steps:

1. install hypixel+ resource pack
2. install Roughly Enough Resources
3. set cache behavior to "every tick" †
4. connect to mc.hypixel.net
5. hit f3+2
6. open inventory
7. browse to the later pages in REI with the top right button

† yes, that is not optimal for performance, but even with a bigger value there, big spikes occur

inspired by #315, combines well with #320

it's a regex, but in many cases it only looks at the first 1-2 characters and aborts VERY quickly, while other types of non-regex checks would need to parse the whole string and eat massive amounts of time

of course the most correct solution is to have a cache that can avoid needing to parse at all, but also distributes its invalidations over time to avoid spikes, however the current performance impacts are ridiculous and deserve quick fixes