### PR TITLE
fixed: any unknown condition breaks cit completely

### DIFF
--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITRegistry.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITRegistry.java
@@ -91,7 +91,7 @@ public final class CITRegistry { private CITRegistry(){}
         CITConditionContainer<? extends CITCondition> conditionContainer = CONDITIONS.get(key);
         if (conditionContainer == null) {
             logWarnLoading(properties.messageWithDescriptorOf("Unknown condition type \"" + key.toString() + "\"", value.position()));
-            return ConstantCondition.FALSE;
+            return ConstantCondition.TRUE;
         }
 
         CITCondition condition = conditionContainer.createCondition.get();

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITRegistry.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITRegistry.java
@@ -91,7 +91,7 @@ public final class CITRegistry { private CITRegistry(){}
         CITConditionContainer<? extends CITCondition> conditionContainer = CONDITIONS.get(key);
         if (conditionContainer == null) {
             logWarnLoading(properties.messageWithDescriptorOf("Unknown condition type \"" + key.toString() + "\"", value.position()));
-            return ConstantCondition.TRUE;
+            return ConstantCondition.FALSE;
         }
 
         CITCondition condition = conditionContainer.createCondition.get();

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/pack/format/PropertiesGroupAdapter.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/pack/format/PropertiesGroupAdapter.java
@@ -26,7 +26,7 @@ public class PropertiesGroupAdapter extends PropertyGroup {
             while ((line = reader.readLine()) != null) {
                 linePos++;
                 line = line.stripLeading();
-                if (line.isEmpty() || line.startsWith("#") || line.startsWith("!") || line.startsWith("%"))
+                if (line.isEmpty() || shouldSkipLine(line))
                     continue;
 
                 while (line.endsWith("\\")) {
@@ -37,7 +37,7 @@ public class PropertiesGroupAdapter extends PropertyGroup {
                         nextLine = "";
                     nextLine = nextLine.stripLeading();
 
-                    if (nextLine.startsWith("#") || nextLine.startsWith("!") || nextLine.startsWith("%"))
+                    if (shouldSkipLine(nextLine))
                         continue;
 
                     line = line.substring(0, line.length() - 1) + "\\n" + nextLine;
@@ -97,5 +97,11 @@ public class PropertiesGroupAdapter extends PropertyGroup {
             }
         }
         return this;
+    }
+
+    private static boolean shouldSkipLine(String line) {
+        return line.startsWith("#") ||
+                line.startsWith("!") ||
+                line.startsWith("%");
     }
 }

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/pack/format/PropertiesGroupAdapter.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/pack/format/PropertiesGroupAdapter.java
@@ -102,6 +102,6 @@ public class PropertiesGroupAdapter extends PropertyGroup {
     private static boolean shouldSkipLine(String line) {
         return line.startsWith("#") ||
                 line.startsWith("!") ||
-                line.startsWith("%");
+                line.startsWith("$");
     }
 }

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/pack/format/PropertiesGroupAdapter.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/pack/format/PropertiesGroupAdapter.java
@@ -26,7 +26,7 @@ public class PropertiesGroupAdapter extends PropertyGroup {
             while ((line = reader.readLine()) != null) {
                 linePos++;
                 line = line.stripLeading();
-                if (line.isEmpty() || line.startsWith("#") || line.startsWith("!"))
+                if (line.isEmpty() || line.startsWith("#") || line.startsWith("!") || line.startsWith("%"))
                     continue;
 
                 while (line.endsWith("\\")) {
@@ -37,7 +37,7 @@ public class PropertiesGroupAdapter extends PropertyGroup {
                         nextLine = "";
                     nextLine = nextLine.stripLeading();
 
-                    if (nextLine.startsWith("#") || nextLine.startsWith("!"))
+                    if (nextLine.startsWith("#") || nextLine.startsWith("!") || nextLine.startsWith("%"))
                         continue;
 
                     line = line.substring(0, line.length() - 1) + "\\n" + nextLine;


### PR DESCRIPTION
So all i did is i changed ConstantCondition.FALSE to TRUE that will be attached to list of conditions for cit in case a condition is unknown for CITR.

I was making a new feature for my mod, this feature requares a parameter in .properties file. So i implemented it, started testing and my feature works well, but the cit itself breaked. I started looking for cause of its issue and fould out that code adds unreachable condition. I tested on OptiFine and there the cit works fine with my feature. I thought of possibility to use api to register it as my mod's condition, but api is deprecated and i do not want for resource pakcs work only with my mod. 
I also thought about using commented line in .properties file but its tooooooo strange and not practical and difficult to implement as commented lines are ignored by default and its just not cool as the .properties funcional already gives ability to get values from it.

So, why to make cit unreachable? If there is a misstake in properties file it will be ignored competely. If other mod uses CITR's api (what is most likely not) to add its custom condition, cits with this condition won't work at all without this mod. And as packs are not depend on mod loader, on forge (with OF) it will work, but not with cit resewn.
_I mean this pull request was not made esspecially for me and my goals, i made it cause i found an issue while reaching my goals and fixed it._
 
This change should not break any already existed resource pack.

OR may be to add some tag to the beggining of condition line as "IGNORE" or idk mb "::" or any else that will tell CITR that this condition should be ignored and not parsed through?