### PR TITLE
1.21 Components Finishing Touches

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,2 +1,3 @@
- - Fixed CITs not being checked on the first cache interval
- - Fixed CITs not matching correctly in cases where the root element of a json is a string
+ - Ported to 1.21
+ - New format changes from nbt conditions to components for parity with optifine. [See #447](https://github.com/SHsuperCM/CITResewn/pull/447). 
+ - Temporarily disabled enchantment glint CITs.

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
@@ -7,6 +7,7 @@ import net.minecraft.component.ComponentType;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.registry.Registries;
+import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import shcm.shsupercm.fabric.citresewn.CITResewn;
 import shcm.shsupercm.fabric.citresewn.api.CITConditionContainer;
@@ -68,7 +69,12 @@ public class ConditionComponents extends CITCondition {
         /*?>=1.21 {?*/
         Object stackComponent = context.stack.getComponents().get(this.componentType);
         if (stackComponent != null) {
-
+            if (stackComponent instanceof Text text) {
+                if (this.fallbackNBTCheck.testString(null, text, context))
+                    return true;
+            } /*else if (stackComponent instanceof LoreComponent lore) {
+                //todo avoid nbt based check if possible
+            }*/
 
             NbtElement fallbackComponentNBT = ((ComponentType<Object>) this.componentType).getCodec().encodeStart(NbtOps.INSTANCE, stackComponent).getOrThrow();
             return this.fallbackNBTCheck.testPath(fallbackComponentNBT, 0, context);

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
@@ -1,6 +1,7 @@
 package shcm.shsupercm.fabric.citresewn.defaults.cit.conditions;
 
 import io.shcm.shsupercm.fabric.fletchingtable.api.Entrypoint;
+import shcm.shsupercm.fabric.citresewn.CITResewn;
 import shcm.shsupercm.fabric.citresewn.api.CITConditionContainer;
 import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
@@ -16,7 +17,17 @@ public class ConditionComponents extends CITCondition {
 
     @Override
     public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
-        
+        if (key.path().equals("nbt")) {
+            if (value.keyMetadata().startsWith("display.Name")) {
+                value = new PropertyValue("minecraft:custom_name" + value.keyMetadata().substring("display.Name".length()), value.value(), value.separator(), value.position(), value.propertiesIdentifier(), value.packName());
+                CITResewn.logWarnLoading(properties.messageWithDescriptorOf("Using legacy nbt.display.Name", value.position()));
+            } else if (value.keyMetadata().startsWith("display.Lore")) {
+                value = new PropertyValue("minecraft:lore" + value.keyMetadata().substring("display.Lore".length()), value.value(), value.separator(), value.position(), value.propertiesIdentifier(), value.packName());
+                CITResewn.logWarnLoading(properties.messageWithDescriptorOf("Using legacy nbt.display.Lore", value.position()));
+            } else
+                throw new CITParsingException("NBT condition is not supported since 1.21", properties, value.position());
+        }
+
     }
 
     @Override

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
@@ -20,6 +20,9 @@ public class ConditionComponents extends CITCondition {
 
     private ComponentType<?> componentType;
     private String componentMetadata;
+    private String requiredValue;
+
+    private ConditionNBT fallbackNBTCheck;
 
     @Override
     public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
@@ -40,11 +43,14 @@ public class ConditionComponents extends CITCondition {
         String componentId = metadata.split("\\.")[0];
 
         if ((this.componentType = Registries.DATA_COMPONENT_TYPE.get(Identifier.tryParse(componentId))) == null)
-            throw new CITParsingException("Unknown condition type \"" + componentId + "\"", properties, value.position());
+            throw new CITParsingException("Unknown component type \"" + componentId + "\"", properties, value.position());
 
         this.componentMetadata = metadata = metadata.substring(componentId.length());
 
-        
+        this.requiredValue = value.value();
+
+        this.fallbackNBTCheck = new ConditionNBT();
+        this.fallbackNBTCheck.loadNbtCondition(value, properties, metadata.split("\\."), this.requiredValue);
     }
 
     @Override

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
@@ -1,0 +1,26 @@
+package shcm.shsupercm.fabric.citresewn.defaults.cit.conditions;
+
+import io.shcm.shsupercm.fabric.fletchingtable.api.Entrypoint;
+import shcm.shsupercm.fabric.citresewn.api.CITConditionContainer;
+import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
+import shcm.shsupercm.fabric.citresewn.cit.CITContext;
+import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
+
+public class ConditionComponents extends CITCondition {
+    /*?>=1.21 {?*/@Entrypoint(CITConditionContainer.ENTRYPOINT)/*?}?*/
+    public static final CITConditionContainer<ConditionComponents> CONTAINER = new CITConditionContainer<>(ConditionComponents.class, ConditionComponents::new,
+            "components", "component", "nbt");
+
+    @Override
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
+        
+    }
+
+    @Override
+    public boolean test(CITContext context) {
+        return false;
+    }
+}

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionEnchantments.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionEnchantments.java
@@ -1,7 +1,6 @@
 package shcm.shsupercm.fabric.citresewn.defaults.cit.conditions;
 
 import io.shcm.shsupercm.fabric.fletchingtable.api.Entrypoint;
-import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 import shcm.shsupercm.fabric.citresewn.api.CITConditionContainer;
 import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
@@ -10,6 +9,7 @@ import shcm.shsupercm.fabric.citresewn.cit.builtin.conditions.IdentifierConditio
 import shcm.shsupercm.fabric.citresewn.cit.builtin.conditions.ListCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import java.util.Set;
@@ -39,8 +39,8 @@ public class ConditionEnchantments extends ListCondition<ConditionEnchantments.E
 
     protected static class EnchantmentCondition extends IdentifierCondition {
         @Override
-        public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
-            super.load(value, properties);
+        public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
+            super.load(key, value, properties);
 
             /*?<1.21 {?*//*
             if (!Registries.ENCHANTMENT.containsId(this.value))

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionItems.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionItems.java
@@ -10,6 +10,7 @@ import shcm.shsupercm.fabric.citresewn.cit.builtin.conditions.IdentifierConditio
 import shcm.shsupercm.fabric.citresewn.cit.builtin.conditions.ListCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import java.util.LinkedHashSet;
@@ -32,8 +33,8 @@ public class ConditionItems extends ListCondition<ConditionItems.ItemCondition> 
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
-        super.load(value, properties);
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
+        super.load(key, value, properties);
 
         Set<Item> items = new LinkedHashSet<>();
 
@@ -56,8 +57,8 @@ public class ConditionItems extends ListCondition<ConditionItems.ItemCondition> 
         public Item item = null;
 
         @Override
-        public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
-            super.load(value, properties);
+        public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
+            super.load(key, value, properties);
 
             if (Registries.ITEM.containsId(this.value))
                 this.item = Registries.ITEM.get(this.value);

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -8,6 +8,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import java.util.Locale;
@@ -31,7 +32,7 @@ public class ConditionNBT extends CITCondition {
     protected NbtCompound matchCompound = null;
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         if (value.keyMetadata() == null || value.keyMetadata().isEmpty())
             throw new CITParsingException("Missing nbt path", properties, value.position());
 

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -134,18 +134,9 @@ public class ConditionNBT extends CITCondition {
 
     public boolean testValue(NbtElement element, CITContext context) {
         try {
-            if (element instanceof NbtString nbtString) { //noinspection ConstantConditions
-                String elementString = nbtString.asString();
-                if (matchString.matches(elementString))
-                    return true;
-                for (int i = 0; i < elementString.length(); i++) {
-                    char ch = elementString.charAt(i);
-                    if (Character.isWhitespace(ch))
-                        continue;
-
-                    return (ch == '[' || ch == '{' || ch == '"') && matchString.matches(Text./*?>=1.20.4 {?*/Serialization/*?} else {?*//*Serializer/*?}?*/.fromJson(elementString/*?>=1.21 {?*/, context.world.getRegistryManager()/*?}?*/).getString());
-                }
-            } else if (element instanceof NbtInt nbtInt && matchInteger != null)
+            if (element instanceof NbtString nbtString)
+                return testString(nbtString.asString(), null, context);
+            else if (element instanceof NbtInt nbtInt && matchInteger != null)
                 return nbtInt.equals(matchInteger);
             else if (element instanceof NbtByte nbtByte && matchByte != null)
                 return nbtByte.equals(matchByte);
@@ -164,6 +155,22 @@ public class ConditionNBT extends CITCondition {
                 return matchString.matches(String.valueOf(nbtNumber.numberValue()));
         } catch (Exception ignored) { }
         return false;
+    }
+
+    public boolean testString(String element, Text elementText, CITContext context) {
+        if (element != null) {
+            if (matchString.matches(element))
+                return true;
+
+            if (elementText == null)
+                elementText = Text./*?>=1.20.4 {?*/Serialization/*?} else {?*//*Serializer/*?}?*/
+                        .fromJson(element/*?>=1.21 {?*/, context.world.getRegistryManager()/*?}?*/);
+        }
+
+        if (elementText == null)
+            return false;
+
+        return matchString.matches(elementText.getString());
     }
 
     protected static abstract class StringMatcher {

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 public class ConditionNBT extends CITCondition {
-    @Entrypoint(CITConditionContainer.ENTRYPOINT)
+    /*?<1.21 {?*//*@Entrypoint(CITConditionContainer.ENTRYPOINT)/*?}?*/
     public static final CITConditionContainer<ConditionNBT> CONTAINER = new CITConditionContainer<>(ConditionNBT.class, ConditionNBT::new,
             "nbt");
 
@@ -84,37 +84,40 @@ public class ConditionNBT extends CITCondition {
 
     @Override
     public boolean test(CITContext context) {
-        return false;
-        //todo 1205 return testPath(context.stack.getNbt(), 0);
+        /*?>=1.21 {?*/
+        throw new AssertionError("NBT condition replaced with component condition in 1.21");
+        /*?} else {?*//*
+        return testPath(context.stack.getNbt(), 0, context);
+        /*?}?*/
     }
 
-    protected boolean testPath(NbtElement element, int pathIndex) {
+    protected boolean testPath(NbtElement element, int pathIndex, CITContext context) {
         if (element == null)
             return false;
 
         if (pathIndex >= path.length)
-            return testValue(element);
+            return testValue(element, context);
 
         final String path = this.path[pathIndex];
         if (path.equals("*")) {
             if (element instanceof NbtCompound compound) {
                 for (NbtElement subElement : compound.entries.values())
-                    if (testPath(subElement, pathIndex + 1))
+                    if (testPath(subElement, pathIndex + 1, context))
                         return true;
             } else if (element instanceof NbtList list) {
                 for (NbtElement subElement : list)
-                    if (testPath(subElement, pathIndex + 1))
+                    if (testPath(subElement, pathIndex + 1, context))
                         return true;
             }
         } else {
             if (element instanceof NbtCompound compound)
-                return testPath(compound.get(path), pathIndex + 1);
+                return testPath(compound.get(path), pathIndex + 1, context);
             else if (element instanceof NbtList list) {
                 if (path.equals("count"))
-                    return testValue(NbtInt.of(list.size()));
+                    return testValue(NbtInt.of(list.size()), context);
 
                 try {
-                    return testPath(list.get(Integer.parseInt(path)), pathIndex + 1);
+                    return testPath(list.get(Integer.parseInt(path)), pathIndex + 1, context);
                 } catch (NumberFormatException | IndexOutOfBoundsException ignored) { }
             }
         }
@@ -122,7 +125,7 @@ public class ConditionNBT extends CITCondition {
         return false;
     }
 
-    private boolean testValue(NbtElement element) {
+    private boolean testValue(NbtElement element, CITContext context) {
         try {
             if (element instanceof NbtString nbtString) { //noinspection ConstantConditions
                 String elementString = nbtString.asString();
@@ -133,8 +136,7 @@ public class ConditionNBT extends CITCondition {
                     if (Character.isWhitespace(ch))
                         continue;
 
-                    //todo 1205  return (ch == '[' || ch == '{' || ch == '"') && matchString.matches(Text./*?>=1.20.4 {?*/Serialization/*?} else {?*//*Serializer/*?}?*/.fromJson(elementString).getString());
-                    return false;
+                    return (ch == '[' || ch == '{' || ch == '"') && matchString.matches(Text./*?>=1.20.4 {?*/Serialization/*?} else {?*//*Serializer/*?}?*/.fromJson(elementString/*?>=1.21 {?*/, context.world.getRegistryManager()/*?}?*/).getString());
                 }
             } else if (element instanceof NbtInt nbtInt && matchInteger != null)
                 return nbtInt.equals(matchInteger);

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -36,50 +36,56 @@ public class ConditionNBT extends CITCondition {
         if (value.keyMetadata() == null || value.keyMetadata().isEmpty())
             throw new CITParsingException("Missing nbt path", properties, value.position());
 
-        path = value.keyMetadata().split("\\.");
-        for (String s : path)
+        String[] nbtPath = value.keyMetadata().split("\\.");
+        for (String s : nbtPath)
             if (s.isEmpty())
                 throw new CITParsingException("Path segment cannot be empty", properties, value.position());
 
+        loadNbtCondition(value, properties, nbtPath, value.value());
+    }
+
+    public void loadNbtCondition(PropertyValue value, PropertyGroup properties, String[] path, String nbtValue) throws CITParsingException {
+        this.path = path;
+
         try {
-            if (value.value().startsWith("regex:"))
-                matchString = new StringMatcher.RegexMatcher(value.value().substring(6));
-            else if (value.value().startsWith("iregex:"))
-                matchString = new StringMatcher.IRegexMatcher(value.value().substring(7));
-            else if (value.value().startsWith("pattern:"))
-                matchString = new StringMatcher.PatternMatcher(value.value().substring(8));
-            else if (value.value().startsWith("ipattern:"))
-                matchString = new StringMatcher.IPatternMatcher(value.value().substring(9));
+            if (nbtValue.startsWith("regex:"))
+                matchString = new StringMatcher.RegexMatcher(nbtValue.substring(6));
+            else if (nbtValue.startsWith("iregex:"))
+                matchString = new StringMatcher.IRegexMatcher(nbtValue.substring(7));
+            else if (nbtValue.startsWith("pattern:"))
+                matchString = new StringMatcher.PatternMatcher(nbtValue.substring(8));
+            else if (nbtValue.startsWith("ipattern:"))
+                matchString = new StringMatcher.IPatternMatcher(nbtValue.substring(9));
             else
-                matchString = new StringMatcher.DirectMatcher(value.value());
+                matchString = new StringMatcher.DirectMatcher(nbtValue);
         } catch (PatternSyntaxException e) {
             throw new CITParsingException("Malformatted regex expression", properties, value.position(), e);
         } catch (Exception ignored) { }
         try {
-            if (value.value().startsWith("#"))
-                matchInteger = NbtInt.of(Integer.parseInt(value.value().substring(1).toLowerCase(Locale.ENGLISH), 16));
-            else if (value.value().startsWith("0x"))
-                matchInteger = NbtInt.of(Integer.parseInt(value.value().substring(2).toLowerCase(Locale.ENGLISH), 16));
+            if (nbtValue.startsWith("#"))
+                matchInteger = NbtInt.of(Integer.parseInt(nbtValue.substring(1).toLowerCase(Locale.ENGLISH), 16));
+            else if (nbtValue.startsWith("0x"))
+                matchInteger = NbtInt.of(Integer.parseInt(nbtValue.substring(2).toLowerCase(Locale.ENGLISH), 16));
             else
-                matchInteger = NbtInt.of(Integer.parseInt(value.value()));
+                matchInteger = NbtInt.of(Integer.parseInt(nbtValue));
         } catch (Exception ignored) { }
         try {
-            matchByte = NbtByte.of(Byte.parseByte(value.value()));
+            matchByte = NbtByte.of(Byte.parseByte(nbtValue));
         } catch (Exception ignored) { }
         try {
-            matchFloat = NbtFloat.of(Float.parseFloat(value.value()));
+            matchFloat = NbtFloat.of(Float.parseFloat(nbtValue));
         } catch (Exception ignored) { }
         try {
-            matchDouble = NbtDouble.of(Double.parseDouble(value.value()));
+            matchDouble = NbtDouble.of(Double.parseDouble(nbtValue));
         } catch (Exception ignored) { }
         try {
-            matchLong = NbtLong.of(Long.parseLong(value.value()));
+            matchLong = NbtLong.of(Long.parseLong(nbtValue));
         } catch (Exception ignored) { }
         try {
-            matchShort = NbtShort.of(Short.parseShort(value.value()));
+            matchShort = NbtShort.of(Short.parseShort(nbtValue));
         } catch (Exception ignored) { }
         try {
-            matchCompound = StringNbtReader.parse(value.value());
+            matchCompound = StringNbtReader.parse(nbtValue);
         } catch (Exception ignored) { }
     }
 
@@ -92,7 +98,7 @@ public class ConditionNBT extends CITCondition {
         /*?}?*/
     }
 
-    protected boolean testPath(NbtElement element, int pathIndex, CITContext context) {
+    public boolean testPath(NbtElement element, int pathIndex, CITContext context) {
         if (element == null)
             return false;
 
@@ -126,7 +132,7 @@ public class ConditionNBT extends CITCondition {
         return false;
     }
 
-    private boolean testValue(NbtElement element, CITContext context) {
+    public boolean testValue(NbtElement element, CITContext context) {
         try {
             if (element instanceof NbtString nbtString) { //noinspection ConstantConditions
                 String elementString = nbtString.asString();

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.workers.max=1
 
 # CIT Resewn
-mod.version=1.1.5
+mod.version=1.2.0
 mod.jarname=citresewn
 mod.target-mc=[VERSIONED]
 publish.target-mc=[VERSIONED]

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.CITResewn;
 import shcm.shsupercm.fabric.citresewn.api.CITConditionContainer;
 import shcm.shsupercm.fabric.citresewn.config.CITResewnConfig;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import java.util.Collections;
@@ -18,11 +19,13 @@ import java.util.Set;
 public abstract class CITCondition {
     /**
      * Parses the given property value into the condition.
-     * @param value value to read
+     *
+     * @param key        key for this condition
+     * @param value      value to read
      * @param properties the group containing value
      * @throws CITParsingException if errored while parsing the condition
      */
-    public abstract void load(PropertyValue value, PropertyGroup properties) throws CITParsingException;
+    public abstract void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException;
 
     /**
      * @return a set of classes of conditions that have integration with this condition

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITRegistry.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITRegistry.java
@@ -95,7 +95,7 @@ public final class CITRegistry { private CITRegistry(){}
         }
 
         CITCondition condition = conditionContainer.createCondition.get();
-        condition.load(value, properties);
+        condition.load(key, value, properties);
         return condition;
     }
 

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/BooleanCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/BooleanCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 /**
@@ -25,7 +26,7 @@ public abstract class BooleanCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         if (value.value().equalsIgnoreCase("true"))
             this.value = true;
         else if (value.value().equalsIgnoreCase("false"))

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/ConstantCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/ConstantCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 /**
@@ -47,5 +48,5 @@ public abstract class ConstantCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException { }
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException { }
 }

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/DoubleCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/DoubleCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import static java.lang.Double.*;
@@ -52,7 +53,7 @@ public abstract class DoubleCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         String strValue = value.value();
         if (supportsPercentages && (percentage = strValue.contains("%")))
             strValue = strValue.replace("%", "");

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/EnumCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/EnumCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import java.util.function.Supplier;
@@ -47,7 +48,7 @@ public abstract class EnumCondition<T extends Enum<? extends EnumCondition.Alias
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         for (T enumConstant : values.get())
             for (String alias : ((Aliased) enumConstant).getAliases())
                 if (ignoreCase ? alias.equalsIgnoreCase(value.value()) : alias.equals(value.value())) {

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/FloatCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/FloatCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import static java.lang.Float.*;
@@ -52,7 +53,7 @@ public abstract class FloatCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         String strValue = value.value();
         if (supportsPercentages && (percentage = strValue.contains("%")))
             strValue = strValue.replace("%", "");

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/IdentifierCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/IdentifierCondition.java
@@ -6,6 +6,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 /**
@@ -27,7 +28,7 @@ public abstract class IdentifierCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         try {
             this.value = Identifier.tryParse(value.value());
         } catch (InvalidIdentifierException e) {

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/IntegerCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/IntegerCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import static java.lang.Integer.*;
@@ -52,7 +53,7 @@ public abstract class IntegerCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         String strValue = value.value();
         if (supportsPercentages && (percentage = strValue.contains("%")))
             strValue = strValue.replace("%", "");

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/ListCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/ListCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import java.lang.reflect.Array;
@@ -59,12 +60,12 @@ public abstract class ListCondition<T extends CITCondition> extends CITCondition
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         List<T> conditions = new ArrayList<>();
 
         for (String conditionValue : delimiter.split(value.value())) {
             T condition = conditionSupplier.get();
-            condition.load(new PropertyValue(value.keyMetadata(), conditionValue, value.separator(), value.position(), value.propertiesIdentifier(), value.packName()), properties);
+            condition.load(key, new PropertyValue(value.keyMetadata(), conditionValue, value.separator(), value.position(), value.propertiesIdentifier(), value.packName()), properties);
             conditions.add(condition);
         }
 

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/LongCondition.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/builtin/conditions/LongCondition.java
@@ -4,6 +4,7 @@ import shcm.shsupercm.fabric.citresewn.cit.CITCondition;
 import shcm.shsupercm.fabric.citresewn.cit.CITContext;
 import shcm.shsupercm.fabric.citresewn.cit.CITParsingException;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
+import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
 import static java.lang.Long.*;
@@ -52,7 +53,7 @@ public abstract class LongCondition extends CITCondition {
     }
 
     @Override
-    public void load(PropertyValue value, PropertyGroup properties) throws CITParsingException {
+    public void load(PropertyKey key, PropertyValue value, PropertyGroup properties) throws CITParsingException {
         String strValue = value.value();
         if (supportsPercentages && (percentage = strValue.contains("%")))
             strValue = strValue.replace("%", "");

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -1,4 +1,4 @@
-mod.target-mc=1.21.0 - 1.21.1
+mod.target-mc=>=1.21 <=1.21.1
 publish.target-mc=1.21,1.21.1
 deps.yarn=1.21+build.9
 deps.fabric-api=0.100.7+1.21

--- a/versions/1.21/gradle.properties
+++ b/versions/1.21/gradle.properties
@@ -1,5 +1,5 @@
-mod.target-mc=1.21
-publish.target-mc=1.21
+mod.target-mc=1.21.0 - 1.21.1
+publish.target-mc=1.21,1.21.1
 deps.yarn=1.21+build.9
 deps.fabric-api=0.100.7+1.21
 deps.modmenu=11.0.1


### PR DESCRIPTION
At long last there is an actual specification for the new item components in 1.21.
```properties
# (Optional) Component-based rule.  Use the replacement texture only when an item component
# has a specific value.  If multiple rules are provided, all of them must match.
# Use a command like "/data get entity @s SelectedItem" to view the item components.
# The component namespace must have a "\" before the ":"
#   components.minecraft\:custom_name=<value>
# If the component name doesn't have a namespace, the default "minecraft:" is automatically used.
#   components.lore -> components.minecraft\:lore
# For further atributes/properties the shortcut "~" can be used instead of the default namespace.
#   components.enchantments.levels.~thorns -> components.minecraft\:enchantments.levels.minecraft\:thorns
# Some legacy NBT checks are still recognized as component names:
#   nbt.display.Name -> components.minecraft\:custom_name
#   nbt.display.Lore -> components.minecraft\:lore
# See: https://minecraft.wiki/w/Data_component_format
components.<name>=<value>
```
Specification might be updated as more things are announced on optifine's side. Goal for now is to do full parity with optifine on the new component changes.


- [x] New `components` condition
- [x] Component parsing
- [x] Component class type optimizations and handling
    - [x] Text
    - [x] ~Lore~
    - [x] Fallback to serialized nbt parser
- [x] Manual mapping conversion for item name and lore from the old `nbt` condition
- [x] 1.21.1 support