### PR TITLE
Cache NbtElement to avoid re-encode causing lag.

### DIFF
--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionComponents.java
@@ -16,6 +16,8 @@ import shcm.shsupercm.fabric.citresewn.pack.format.PropertyGroup;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyKey;
 import shcm.shsupercm.fabric.citresewn.pack.format.PropertyValue;
 
+import java.util.function.Supplier;
+
 public class ConditionComponents extends CITCondition {
     /*? >=1.21*/ @Entrypoint(CITConditionContainer.ENTRYPOINT)
     public static final CITConditionContainer<ConditionComponents> CONTAINER = new CITConditionContainer<>(ConditionComponents.class, ConditionComponents::new,
@@ -75,8 +77,8 @@ public class ConditionComponents extends CITCondition {
             } /*else if (stackComponent instanceof LoreComponent lore) {
                 //todo avoid nbt based check if possible
             }*/
-
-            NbtElement fallbackComponentNBT = ((ComponentType<Object>) this.componentType).getCodec().encodeStart(context.world.getRegistryManager().getOps(NbtOps.INSTANCE), stackComponent).getOrThrow();
+            Supplier<NbtElement> supplier = () -> ((ComponentType<Object>) this.componentType).getCodec().encodeStart(context.world.getRegistryManager().getOps(NbtOps.INSTANCE), stackComponent).getOrThrow();
+            NbtElement fallbackComponentNBT = context.getNbtElementOrLoad(this.componentType, supplier);
             return this.fallbackNBTCheck.testPath(fallbackComponentNBT, 0, context);
         }
         /*?}*/

--- a/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
+++ b/defaults/src/main/java/shcm/shsupercm/fabric/citresewn/defaults/cit/conditions/ConditionNBT.java
@@ -158,12 +158,19 @@ public class ConditionNBT extends CITCondition {
         return false;
     }
 
+    private static boolean likesJson(String value){
+        int index = 0;
+        while (index < value.length() && Character.isWhitespace(value.charAt(index)))
+            index++;
+        return index < value.length() && (value.charAt(index) == '{' || value.charAt(index) == '[');
+    }
+
     public boolean testString(String element, Text elementText, CITContext context) {
         if (element != null) {
             if (matchString.matches(element))
                 return true;
 
-            if (elementText == null)
+            if (elementText == null && likesJson(element))
                 elementText = Text./*? >=1.20.4 {*/Serialization/*?} else {*//*Serializer*//*?}*/
                         .fromJson(element/*? >=1.21 {*/, context.world.getRegistryManager()/*?}*/);
         }

--- a/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITContext.java
+++ b/src/main/java/shcm/shsupercm/fabric/citresewn/cit/CITContext.java
@@ -1,12 +1,10 @@
 package shcm.shsupercm.fabric.citresewn.cit;
 
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.component.ComponentType;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.item.EnchantedBookItem;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.registry.RegistryKey;
@@ -17,6 +15,7 @@ import net.minecraft.world.World;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Holds momentary information to be used for CITs' condition matching and type effects.
@@ -43,6 +42,8 @@ public class CITContext {
      */
     private Map<Identifier, Integer> enchantments = null;
 
+    private Map<ComponentType<?>, NbtElement> cachedComponents = new LinkedHashMap<>();
+
     public CITContext(ItemStack stack, World world, LivingEntity entity) {
         this.stack = stack;
         this.world = world == null ? MinecraftClient.getInstance().world : world;
@@ -66,6 +67,13 @@ public class CITContext {
 
         }
         return this.enchantments;
+    }
+
+    /**
+     * @return the item's NBT element or using provided loader to initialize it.
+     */
+    public NbtElement getNbtElementOrLoad(ComponentType<?> componentType, Supplier<NbtElement> loader) {
+        return this.cachedComponents.computeIfAbsent(componentType, k -> loader.get());
     }
 
     @Override


### PR DESCRIPTION
While loading large cit resourcepacks based on nbt, there's a noticeable performance issue, and the following screenshot shows that `com.mojang.serialization.Encoder.encodeStart()` is called inside test() every time, but the componentNBT should always be the same, so maybe it's better to be cached.
![图片](https://github.com/user-attachments/assets/c9015fb5-5199-4f97-a01b-8725ad861189)

Before:
![图片](https://github.com/user-attachments/assets/180ab526-252d-4379-af63-214b0eaf2f3c)

After:
![图片](https://github.com/user-attachments/assets/10a1e0e8-8b9c-4c79-81d1-63932e48caf5)
